### PR TITLE
Closure improvement + tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,12 @@
         }
     ],
     "require": {
-        "php": ">=5.3.0"
+        "php": ">=5.3.0",
+        "laravel/framework": ">=4.1.0"
+    },
+    "require-dev": {
+        "mockery/mockery": "dev-master",
+        "phpunit/phpunit": "3.7.*"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit backupGlobals="false"
          backupStaticAttributes="false"
-         bootstrap="vendor/autoload.php"
+         bootstrap="tests/bootstrap.php"
          colors="true"
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"

--- a/tests/Widget/WidgetTest.php
+++ b/tests/Widget/WidgetTest.php
@@ -1,0 +1,91 @@
+<?php namespace Widget;
+
+use Pingpong\Widget\Widget as Widget;
+
+class Foo {
+    function run($echo = 'bar'){
+        return $echo;
+    }
+    function handle($echo = 'baz'){
+        return $echo;
+    }
+}
+
+class WidgetTest extends WidgetTestCase
+{
+
+    protected $app;
+
+    public function setUp()
+    {
+
+        parent::setUp();
+
+        $this->widget = new Widget;
+
+    }
+
+    public function testClosures()
+    {
+
+        $this->widget->register(
+                'foo',
+                function ($echo = 'bar') {
+
+                    return $echo;
+
+                }
+        );
+
+        $this->assertEquals('bar', $this->widget->foo());
+        $this->assertEquals('baz', $this->widget->foo('baz'));
+    }
+
+    public function testGroups()
+    {
+
+        $this->widget->register(
+                'foo',
+                function ($echo = 'bar') {
+
+                    return $echo;
+
+                }
+        );
+
+        $this->widget->register(
+                'boo',
+                function ($echo = 'bar') {
+
+                    return $echo;
+
+                }
+        );
+
+        $this->widget->group('sidebar', array('foo', 'boo'));
+
+        ob_start();
+        $this->widget->sidebar();
+        $result = ob_get_clean();
+
+        $this->assertEquals('barbar', $result);
+
+        ob_start();
+        $this->widget->sidebar(array('baz'),array('baz'));
+        $result = ob_get_clean();
+
+        $this->assertEquals('bazbaz', $result);
+
+    }
+
+    public function testClasses()
+    {
+
+        $this->widget->register('foo','Widget\Foo@run');
+        $this->widget->register('boo','Widget\Foo');
+
+        $this->assertEquals('bar', $this->widget->foo());
+        $this->assertEquals('baz', $this->widget->boo('baz'));
+    }
+
+}

--- a/tests/Widget/WidgetTestCase.php
+++ b/tests/Widget/WidgetTestCase.php
@@ -1,0 +1,28 @@
+<?php  namespace Widget;
+
+use Mockery as m;
+
+/**
+ * Class WidgetTestCase
+ */
+class WidgetTestCase extends \PHPUnit_Framework_TestCase {
+
+    protected $useDatabase = true;
+
+    protected $artisan;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        //setup env
+    }
+
+    public function teardown()
+    {
+        m::close();
+    }
+
+
+
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,6 @@
+<?php
+
+$loader = require __DIR__ . "/../vendor/autoload.php";
+$loader->add('Widget\\', 'tests');
+
+putenv('SKIP_BLADE=1');


### PR DESCRIPTION
Now we can set closure as a path to class or class with method like this:
Widget::register('awesome', 'Acme\Widgets\Header@run');
Widget::register('awesome2', 'Acme\Widgets\Footer');

And I think it's better to have one interface in methods call (
@awesome() - for widget
@sidebar() - for group
)
