### PR TITLE
Update illuminate/html version.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "illuminate/support": "5.1.*",
     "illuminate/container": "5.1.*",
     "illuminate/view": "5.1.*",
-    "illuminate/html": "5.1.*",
+    "illuminate/html": "~5.0",
     "illuminate/routing": "5.1.*"
   },
   "require-dev": {


### PR DESCRIPTION
Latest available version of illuminate/html is 5.0.0. The repository is in read-only mode and no further updates will be made. Fixes the issue of installable set of packages.